### PR TITLE
fix: Add sort ascending by string length in versions.tf files keys array

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -4,7 +4,7 @@ const regExprRequiredVersion = /(?<=(required_version.=.)).*/;
 
 export async function versionConstraintSearch(dir: string): Promise<string> {
   const files = await findInFiles.find('required_versions*s*', dir, '.tf$');
-  const key = Object.keys(files)[0];
+  const key = Object.keys(files).sort((a, b) => a.length - b.length)[0];
   const line = files[key].line;
 
   if (line) {


### PR DESCRIPTION
## Description
Hi! 
Added a simple fix to sort ascending the array keys of versions.tf files. With this we can ensure that the first value will be the versions.tf file of the root path.

## Motivation and Context
The motivation for this change is to solve the problem of PR https://github.com/terraform-aws-modules/terraform-aws-alb/pull/264

## How Has This Been Tested?
Example of the array obtained in different cases.

- Before fix:

```
["wrappers/versions.tf","versions.tf","tests/terraform-aws-alb/wrappers/versions.tf","tests/terraform-aws-alb/versions.tf","tests/terraform-aws-alb/examples/complete-nlb/versions.tf","tests/terraform-aws-alb/examples/complete-alb/versions.tf","tests/0.13/versions.tf","tests/0.12/versions.tf"]
```

- After fix:

```
["versions.tf","wrappers/versions.tf","tests/0.13/versions.tf","tests/0.12/versions.tf","tests/terraform-aws-alb/versions.tf","tests/terraform-aws-alb/wrappers/versions.tf","tests/terraform-aws-alb/examples/complete-nlb/versions.tf","tests/terraform-aws-alb/examples/complete-alb/versions.tf"]
```

## Screenshots (if appropriate):
