### PR TITLE
fix: Update versions used in CI workflows to remove deprecated versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,15 +17,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: '20.x'
 
       - name: Release
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       directories: ${{ steps.dirs.outputs.directories }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get root directories
         id: dirs
@@ -31,7 +31,7 @@ jobs:
         directory: ${{ fromJson(needs.collectInputs.outputs.directories) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Terraform min/max versions
         id: minMax
@@ -44,7 +44,7 @@ jobs:
         run: rm -rf $(which terraform)
 
       - name: Install Terraform ${{ steps.minMax.outputs.minVersion }}
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ steps.minMax.outputs.minVersion }}
 
@@ -59,7 +59,7 @@ jobs:
         run: rm -rf $(which terraform)
 
       - name: Install Terraform ${{ steps.minMax.outputs.maxVersion }}
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ steps.minMax.outputs.maxVersion }}
 


### PR DESCRIPTION
## Description
- Update versions used in CI workflows to remove deprecated versions

## Motivation and Context
- CI is currently failing with 
![image](https://github.com/clowdhaus/terraform-min-max/assets/10913471/434a4571-c733-4e6b-8b7d-afc2f0738dd3)


## How Has This Been Tested?
- CI

## Screenshots (if appropriate):
